### PR TITLE
feature: Close SQLite database on CTRL+C

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,10 +1,16 @@
 import dotenvFlow, { config } from "dotenv-flow";
+import { sqlite } from "./Database";
 import { Client } from "./Structures/Client";
 import { GatewayIntentBits } from "discord.js";
 import { registerEvents } from "./Utils";
 import { runChecks } from "./Checks/Run";
 import path from "path";
 import fs from "fs";
+
+process.on("SIGINT", () => {
+  sqlite.close();
+  process.exit();
+})
 
 dotenvFlow.config({ silent: true });
 


### PR DESCRIPTION
Previously we forgot to close the SQLite database upon the exit of the process (usually through CTRL+C), leaving behind the Write-Ahead-Log and a memory map file of the database.

But now when we close the SQLite database those automatically get merged with the main database, not leaving those behind.