### PR TITLE
refactor: redundancy reduction

### DIFF
--- a/src/Commands/activity.ts
+++ b/src/Commands/activity.ts
@@ -38,7 +38,7 @@ export default {
         const uData = (
           await GraphQLRequest("User", {
             username: vars.username,
-          })
+          }, interaction.ALtoken)
         ).data.User;
         vars.userid = uData?.id;
         if (!vars.userid) throw new Error("Couldn't find user id.");
@@ -51,7 +51,7 @@ export default {
     try {
       const {
         data: { Activity: data },
-      } = await GraphQLRequest("Activity", vars);
+      } = await GraphQLRequest("Activity", vars, interaction.ALtoken);
       if (data) {
         const embed = new EmbedBuilder().setTimestamp(data?.createdAt * 1000);
         switch (data?.__typename) {

--- a/src/Commands/anime.ts
+++ b/src/Commands/anime.ts
@@ -1,7 +1,7 @@
 import { SlashCommandBuilder } from "discord.js";
 import { redis } from "../Caching/redis";
 import type { AnimeQuery } from "../GraphQL/types";
-import { mwOptionalALToken } from "../Middleware/ALToken";
+import { mwGetUserEntry } from "../Middleware/UserEntry";
 import type { CommandWithHook } from "../Structures";
 import { EmbedError, GraphQLRequest, getOptions, handleData, normalize, type CacheEntry } from "../Utils";
 
@@ -13,7 +13,7 @@ export default {
   name,
   usage,
   description,
-  middlewares: [mwOptionalALToken],
+  middlewares: [mwGetUserEntry],
   commandType: "Anilist",
   withBuilder: new SlashCommandBuilder()
     .setName(name)

--- a/src/Commands/manga.ts
+++ b/src/Commands/manga.ts
@@ -1,7 +1,7 @@
 import { SlashCommandBuilder } from "discord.js";
 import { redis } from "../Caching/redis";
 import type { MangaQuery } from "../GraphQL/types";
-import { mwOptionalALToken } from "../Middleware/ALToken";
+import { mwGetUserEntry } from "../Middleware/UserEntry";
 import type { CommandWithHook } from "../Structures";
 import { EmbedError, GraphQLRequest, getOptions, handleData, normalize, type CacheEntry } from "../Utils";
 
@@ -13,7 +13,7 @@ export default {
   name,
   usage,
   description,
-  middlewares: [mwOptionalALToken],
+  middlewares: [mwGetUserEntry],
   commandType: "Anilist",
   withBuilder: new SlashCommandBuilder()
     .setName(name)

--- a/src/Commands/recent.ts
+++ b/src/Commands/recent.ts
@@ -53,7 +53,7 @@ export default {
     try {
       const {
         data: { Page: data },
-      } = await GraphQLRequest("RecentChart", vars);
+      } = await GraphQLRequest("RecentChart", vars, interaction.ALtoken);
       if (!data?.mediaList) return void interaction.editReply({ embeds: [EmbedError("Unable to find specified user", vars)] });
       interaction.editReply({ embeds: [{ description: "Creating image..." }] });
       const canvas = new Jimp(999, 999);

--- a/src/Commands/user.ts
+++ b/src/Commands/user.ts
@@ -42,7 +42,7 @@ export default {
     }
     // Make the HTTP Api request
     try {
-      const { data, headers } = await GraphQLRequest("User", vars);
+      const { data, headers } = await GraphQLRequest("User", vars, interaction.ALtoken);
       const response = data.User;
       if (response) {
         const titleEmbed = new EmbedBuilder()

--- a/src/Middleware/ALToken.ts
+++ b/src/Middleware/ALToken.ts
@@ -11,25 +11,9 @@ async function requireALToken(interaction: UsableInteraction) {
   interaction.ALtoken = await RSACryption(alUser.anilistToken);
 }
 
-async function optionalALToken(interaction: UsableInteraction) {
-  const id = interaction.user.id;
-  const alUser = await getAnilistUser(id);
-  if (alUser && alUser.anilistToken) {
-    interaction.alID = alUser.anilistId;
-    interaction.ALtoken = await RSACryption(alUser.anilistToken);
-  }
-}
-
 export const mwRequireALToken = new Middleware({
   name: "Require AniList Token",
   description: "This middleware enforces the presence of an AniList Token for a given Discord user ID and makes it available for the interaction object",
   run: requireALToken,
-  defer: true,
-});
-
-export const mwOptionalALToken = new Middleware({
-  name: "Optional AniList Token",
-  description: "This middleware makes an AniList token available on the interaction object if present",
-  run: optionalALToken,
   defer: true,
 });

--- a/src/Middleware/UserEntry.ts
+++ b/src/Middleware/UserEntry.ts
@@ -1,15 +1,16 @@
 import { Middleware } from "../Structures/Middleware";
-import { getAnilistUser } from "../Utils/getAnilistUser";
+import { RSACryption, getAnilistUser } from "../Utils";
 
 export const mwGetUserEntry = new Middleware({
   name: "Require AniList Token",
-  description: "This middleware gets you the user's AniList ID and add's it to the interaction object.",
+  description: "This middleware gets you the user's data and add's it to the interaction object if it exists. (ID and Token)",
   defer: true,
   run: async (interaction) => {
     const id = interaction.user.id;
     const alUser = await getAnilistUser(id)
     if (alUser && alUser.anilistId) {
       interaction.alID = alUser.anilistId;
+      interaction.ALtoken = await RSACryption(alUser.anilistToken);
     }
   },
 });


### PR DESCRIPTION
- Removed the optionalALToken middleware since the GetUserEntry middleware did the same thing.
- Users who are privated and have added their token can now use find themselves with commands that require a user since we pass user tokens whilst requesting.