### PR TITLE
Changelog

### DIFF
--- a/src/Commands/synclists.ts
+++ b/src/Commands/synclists.ts
@@ -10,7 +10,7 @@ import { eq } from "drizzle-orm";
 const name = "synclists";
 const usage = "/synclists";
 const description = "Syncs your AniList lists with our bot, allowing for quick access to your lists!";
-const cooldown = 0; // 2 hours in seconds;
+const cooldown = 900; // 15 minutes in seconds;
 
 export default {
   name,

--- a/src/Utils/handleMediaData.ts
+++ b/src/Utils/handleMediaData.ts
@@ -177,7 +177,8 @@ export async function handleData(
           path: `$.${media.id}`,
         }) as Promise<CacheEntry>,
     );
-    const userData = (await Promise.allSettled(mediaPool)).filter((user): user is PromiseFulfilledResult<CacheEntry> => user.status === "fulfilled").flatMap((user) => user.value);
+    const userData = (await Promise.allSettled(mediaPool)).filter((user): user is PromiseFulfilledResult<CacheEntry> => user.status === "fulfilled")
+      .filter(Boolean).flatMap((user) => user.value);
     // console.log(userData.length);
     // console.log(userData);
     console.log(mediaType);
@@ -186,7 +187,9 @@ export async function handleData(
       .setAuthor({ name: `${media.title?.english || "N/A"} | Guild Statistics for ${interaction.guild?.name}` })
       .setImage(media.bannerImage!)
       .setDescription(
-        userData.map((user) => `${hyperlink(user.user!.name, `https://anilist.co/user/${user.user.id}`)}: ${user.progress} ${episodeValue ? ("/ " + episodeValue) : (mediaType === "ANIME" ? "episodes" : "chapters")} | ${fixScoring(user, user.user?.mediaListOptions!.scoreFormat, user.score)}`).join("\n"),
+        userData.map((user) => `${hyperlink(user.user!.name, `https://anilist.co/user/${user.user.id}`)}: ${user.progress} ${episodeValue
+          ? ("/ " + episodeValue) 
+          : (mediaType === "ANIME" ? "episodes" : "chapters")} | ${fixScoring(user, user.user?.mediaListOptions!.scoreFormat, user.score)}`).join("\n"),
       );
     pageList.push(statisticsEmbed);
   }


### PR DESCRIPTION
- Readd cooldown to synclists, but now 15 minutes instead of 2 hours
- In handleMediaData.ts, filter out empty users incase statsdb.sqlite somehow has them even though they shouldn't be there